### PR TITLE
Fix bug with registering to vote

### DIFF
--- a/frontend/src/lib/components/RegisterToVoteScreen.svelte
+++ b/frontend/src/lib/components/RegisterToVoteScreen.svelte
@@ -6,9 +6,11 @@
 	let { onRegistration } = $props();
 	let party = $state('');
 	let errors = $state({});
-	let {game, name, userId, affiliations, rounds } = $currentUser;
+	let {game, name, userId, affiliations } = $currentUser;
+	let rounds = $derived($currentUser.rounds);
 	let partyOptions = $state([]);
 	let gameState = JSON.parse(game.state);
+	// console.log(gameState)
 
 	$effect(() => {
 		if (game) {


### PR DESCRIPTION
Destructured state variables are not reactive by default with Svelte --> use $derived for rounds, which needs to be updated