### PR TITLE
[Feat] Base functionality for frontend to listen for backend SSEs

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -32,6 +32,7 @@
 				"prettier-plugin-tailwindcss": "^0.6.10",
 				"publint": "^0.3.2",
 				"svelte": "^5.0.0",
+				"sveltekit-sse": "^0.13.16",
 				"tailwindcss": "^3.4.17",
 				"typescript": "^5.3.2",
 				"vite": "^6.0.0",
@@ -791,6 +792,14 @@
 			"peerDependencies": {
 				"svelte": "^5.0.0"
 			}
+		},
+		"node_modules/@microsoft/fetch-event-source": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@microsoft/fetch-event-source/-/fetch-event-source-2.0.1.tgz",
+			"integrity": "sha512-W6CLUJ2eBMw3Rec70qrsEW0jOm/3twwJv21mrmj2yORiaVmVYGS4sSS5yUwvQc1ZlDLYGPnClVWmUUMagKNsfA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
@@ -4367,6 +4376,17 @@
 			"peerDependencies": {
 				"svelte": "^3.55 || ^4.0.0-next.0 || ^4.0 || ^5.0.0-next.0",
 				"typescript": "^4.9.4 || ^5.0.0"
+			}
+		},
+		"node_modules/sveltekit-sse": {
+			"version": "0.13.16",
+			"resolved": "https://registry.npmjs.org/sveltekit-sse/-/sveltekit-sse-0.13.16.tgz",
+			"integrity": "sha512-+ORJ5SDeNTYJrEJOQz2Wevsr0OgrZwI5VMT3lhr5vbn7NbClcm+CyXmqtPMtd0dk4B1OCzch34TNmRXoejHK9g==",
+			"dev": true,
+			"peerDependencies": {
+				"@microsoft/fetch-event-source": "^2.0.1",
+				"@sveltejs/kit": "^2.0.0",
+				"svelte": "^4.0.0 || ^5.0.0-next.0"
 			}
 		},
 		"node_modules/tailwindcss": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -53,6 +53,7 @@
 		"prettier-plugin-tailwindcss": "^0.6.10",
 		"publint": "^0.3.2",
 		"svelte": "^5.0.0",
+		"sveltekit-sse": "^0.13.16",
 		"tailwindcss": "^3.4.17",
 		"typescript": "^5.3.2",
 		"vite": "^6.0.0",

--- a/frontend/src/lib/components/AppCore.svelte
+++ b/frontend/src/lib/components/AppCore.svelte
@@ -7,8 +7,13 @@
 	import GameSelectionScreen from '$lib/components/GameSelectionScreen.svelte';
 	import RegisterScreen from './RegisterScreen.svelte';
 	import { currentUser } from '$lib/stores/userData.svelte.js';
-	
-	// First landing on the page renders the regisster view
+	import { PUBLIC_BACKEND_URL } from '$env/static/public';
+	import { createSSEConnection, selectJsonEvent } from '$lib/services/sseService.js'
+
+	// Listen to backend server sent events
+	const connection = createSSEConnection(`${PUBLIC_BACKEND_URL}/sse/game-state`)
+	const jsonData = selectJsonEvent(connection, 'message');
+
 	const { game, name, affiliations, userId } = $currentUser;
 
 	let currentScreen = $state('select');

--- a/frontend/src/lib/services/sseService.js
+++ b/frontend/src/lib/services/sseService.js
@@ -1,0 +1,38 @@
+import { source } from "sveltekit-sse";
+import { SSE_API_KEY } from "$env/static/private";
+
+export function createSSEConnection(endpoint, options = {}) {
+  const defaultOptions = {
+    options: {
+      headers: {
+        "X-API-Key": SSE_API_KEY,
+      },
+    },
+    // Other default configuration here
+  };
+
+  const config = {
+    ...defaultOptions,
+    ...options,
+    options: {
+      ...defaultOptions.options,
+      ...options.options,
+      headers: {
+        ...defaultOptions.options.headers,
+        ...(options.options?.headers || {}),
+      },
+    },
+  };
+
+  return source(endpoint, config);
+}
+
+export function selectJsonEvent(connection, eventName = "message") {
+  return connection.select(eventName).json(({ error, raw }) => {
+    if (error) {
+      console.error("Failed to parse JSON:", raw, error);
+      return false;
+    }
+    return raw;
+  });
+}


### PR DESCRIPTION
This should add the ability for frontend to read (and later react) to changes in game state. 

Game state change events should be coming from `${PUBLIC_BACKEND_URL}/sse/game-state`